### PR TITLE
Remove unnecessary exit condition in read to avoid truncating large state lines

### DIFF
--- a/src/target_s3_json/s3.py
+++ b/src/target_s3_json/s3.py
@@ -242,9 +242,6 @@ class WrappedIoBuffer():
         self.buffer += readData
 
     def read(self, size):
-        if self.empty:
-            self.closed = True
-            return b''
         readSize = 8192 if size == -1 else size
         if len(self.buffer) < readSize:
             self.readMore()


### PR DESCRIPTION

Reproduced the error with some test output. Verified removing these lines fixes the issue