### PR TITLE
enable directories on existing stages

### DIFF
--- a/src/target_s3_json/s3.py
+++ b/src/target_s3_json/s3.py
@@ -313,6 +313,11 @@ def main(lines: TextIO = sys.stdin) -> None:
         # Create Snowflake stage and refresh
         stage = SnowflakeStage(components)
         stage.create_s3_stage(s3_bucket=config['s3_bucket'])
+        
+        # Enabling directory on the stage is necessary as there are existing
+        # stages which may not have the directory enabled
+        # TODO: Remove this once stages are exclusively created by this target
+        stage.enable_directory_on_stage()
         stage.refresh_directory()
             
     except Exception as e:

--- a/src/target_s3_json/s3.py
+++ b/src/target_s3_json/s3.py
@@ -317,6 +317,7 @@ def main(lines: TextIO = sys.stdin) -> None:
         # Enabling directory on the stage is necessary as there are existing
         # stages which may not have the directory enabled
         # TODO: Remove this once stages are exclusively created by this target
+        # https://minware.atlassian.net/browse/MW-5838
         stage.enable_directory_on_stage()
         stage.refresh_directory()
             

--- a/src/target_s3_json/snowflake.py
+++ b/src/target_s3_json/snowflake.py
@@ -129,7 +129,7 @@ class SnowflakeStage:
         """Enable directory on the stage."""
         query = f"ALTER STAGE {self.schema_name}.{self.stage_name} SET DIRECTORY = (ENABLE = TRUE);"
         self.execute_query(query)
-    
+        LOGGER.info(f"Enabled directory on stage: {self.schema_name}.{self.stage_name}")
     def refresh_directory(self) -> None:
         """
         Refresh a Snowflake directory for the stage.

--- a/src/target_s3_json/snowflake.py
+++ b/src/target_s3_json/snowflake.py
@@ -124,6 +124,11 @@ class SnowflakeStage:
         """
         self.execute_query(query)
         LOGGER.info(f"Created or verified stage: {self.schema_name}.{self.stage_name}")
+
+    def enable_directory_on_stage(self) -> None:
+        """Enable directory on the stage."""
+        query = f"ALTER STAGE {self.schema_name}.{self.stage_name} SET DIRECTORY = (ENABLE = TRUE);"
+        self.execute_query(query)
     
     def refresh_directory(self) -> None:
         """

--- a/tests/test_snowflake.py
+++ b/tests/test_snowflake.py
@@ -2,7 +2,8 @@ import pytest
 import json
 import re
 from pathlib import Path
-from target_s3_json.snowflake import parse_path_template, PathComponents
+from unittest.mock import patch, MagicMock
+from target_s3_json.snowflake import parse_path_template, PathComponents, SnowflakeStage
 
 def test_parse_path_template_valid():
     """Test parsing a valid path template."""
@@ -80,3 +81,25 @@ def test_parse_path_template_path_templates():
             # For other sources, repo_id should be a UUID
             assert len(result.repo_id) == 36, f"Invalid UUID length for repo_id: {result.repo_id}"
             assert uuid_pattern.match(result.repo_id), f"Invalid UUID format for repo_id: {result.repo_id}" 
+
+def test_enable_directory_on_stage():
+    """Test that enable_directory_on_stage generates the correct SQL query."""
+    # Create a PathComponents with a known UUID and source
+    components = PathComponents(
+        org_id="e459f0ee-9ed2-4232-bada-dc4c05bdfd10",
+        source="github",
+        repo_id="f159f0ee-9ed2-4232-bada-dc4c05bdfd10"
+    )
+    
+    # Create SnowflakeStage instance
+    stage = SnowflakeStage(components)
+    
+    # Mock execute_query to capture the query
+    with patch.object(stage, 'execute_query') as mock_execute:
+        # Call the function
+        stage.enable_directory_on_stage()
+        
+        # Verify execute_query was called with the correct query
+        mock_execute.assert_called_once_with(
+            "ALTER STAGE T_E459F0EE9ED24232BADADC4C05BDFD10_GITHUB.S3_STAGE SET DIRECTORY = (ENABLE = TRUE);"
+        ) 


### PR DESCRIPTION
If an existing stage didn't have directory enabled, target-json-s3 failed when refreshing the directory for the stage.

This updates the target to enable directories on existing stages.

There's a [follow up ticket](https://minware.atlassian.net/browse/MW-5838) to consider where we actually want to create stages which will impact the long-term need for this change.

Validated by:
1. Unit tests to ensure that we get the statement that we want
2. dev:ingest to make sure that this is executed successflly