### PR TITLE
add cleanup to handle clearing out empty files

### DIFF
--- a/src/target_s3_json/s3.py
+++ b/src/target_s3_json/s3.py
@@ -17,6 +17,7 @@ from boto3.session import Session
 from botocore.exceptions import ClientError
 from botocore.client import BaseClient
 from botocore.client import Config
+from target_s3_json.s3_cleanup import cleanup_empty_jsonl_files
 
 from .stream import Loader
 from .file import config_file, save_json, config_compression
@@ -303,12 +304,18 @@ def main(lines: TextIO = sys.stdin) -> None:
             Loader(config | {'client': client, 'executor': executor, 'add_metadata_columns': True }, writeline=save_s3).run(curLines)
         if not curLines.stoppedState():
             break
-    
+
+        # Parse the path template to get components
+        components = parse_path_template(config['path_template'])
+        
+        # Run cleanup using the parsed components
+        try:
+            cleanup_empty_jsonl_files(bucket=config['s3_bucket'], client=client, path_components=components)
+        except Exception as e:
+            LOGGER.error(f"Failed to cleanup empty JSONL files: {str(e)}")
     # After processing is complete, create and refresh the Snowflake stage
     stage = None
     try:
-        # Parse the path template to get components
-        components = parse_path_template(config['path_template'])
         
         # Create Snowflake stage and refresh
         stage = SnowflakeStage(components)

--- a/src/target_s3_json/s3.py
+++ b/src/target_s3_json/s3.py
@@ -304,15 +304,18 @@ def main(lines: TextIO = sys.stdin) -> None:
             Loader(config | {'client': client, 'executor': executor, 'add_metadata_columns': True }, writeline=save_s3).run(curLines)
         if not curLines.stoppedState():
             break
+    
+    # Parse the path template to get components
+    components = parse_path_template(config['path_template'])
+    
+    # Run cleanup using the parsed components
+    # Remove this after the process has executed for all active ingests
+    # TODO: https://minware.atlassian.net/browse/MW-6495
+    try:
+        cleanup_empty_jsonl_files(bucket=config['s3_bucket'], client=client, path_components=components)
+    except Exception as e:
+        LOGGER.error(f"Failed to cleanup empty JSONL files: {str(e)}")
 
-        # Parse the path template to get components
-        components = parse_path_template(config['path_template'])
-        
-        # Run cleanup using the parsed components
-        try:
-            cleanup_empty_jsonl_files(bucket=config['s3_bucket'], client=client, path_components=components)
-        except Exception as e:
-            LOGGER.error(f"Failed to cleanup empty JSONL files: {str(e)}")
     # After processing is complete, create and refresh the Snowflake stage
     stage = None
     try:

--- a/src/target_s3_json/s3_cleanup.py
+++ b/src/target_s3_json/s3_cleanup.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+
+import json
+from typing import Dict, Any, Generator, List, Callable
+
+import backoff
+import boto3
+from botocore.exceptions import ClientError
+from botocore.client import BaseClient
+
+from .snowflake import PathComponents
+from target._logger import get_logger
+
+LOGGER = get_logger()
+
+
+def _log_backoff_attempt(details: Dict) -> None:
+    LOGGER.info("Error detected communicating with Amazon, triggering backoff: %d try", details.get("tries"))
+
+
+def _retry_pattern() -> Callable:
+    return backoff.on_exception(
+        backoff.expo,
+        ClientError,
+        max_tries=5,
+        on_backoff=_log_backoff_attempt,
+        factor=10)
+
+
+def has_record_entries(content: bytes) -> bool:
+    """
+    Check if JSONL content contains any entries with type="RECORD"
+    Optimized to check only the second line since RECORD entries are always on the second line.
+    
+    Args:
+        content: Raw bytes content of the JSONL file
+        
+    Returns:
+        True if file contains at least one RECORD entry, False otherwise
+    """
+    try:
+        # Decode to text
+        text_content = content.decode('utf-8')
+        lines = text_content.strip().split('\n')
+        
+        # Check only the second line (index 1) since RECORD entries are always there
+        if len(lines) < 2:
+            return False  # No second line means no RECORD entries
+        
+        second_line = lines[1].strip()
+        if not second_line:
+            return False  # Empty second line means no RECORD entries
+        
+        try:
+            record = json.loads(second_line)
+            return record.get('type') == 'RECORD'
+        except json.JSONDecodeError:
+            LOGGER.warning(f"Failed to parse JSON on second line: {second_line[:100]}...")
+            return False
+                
+    except Exception as e:
+        LOGGER.error(f"Error processing file content: {str(e)}")
+        return True  # Conservative approach: keep file if we can't process it
+
+
+
+@_retry_pattern()
+def list_s3_objects(client: BaseClient, bucket: str, prefix: str = '') -> Generator[Dict[str, Any], None, None]:
+    """
+    List all objects in S3 bucket with given prefix recursively
+    
+    Args:
+        client: S3 client
+        bucket: S3 bucket name
+        prefix: Key prefix to filter objects
+        
+    Yields:
+        Dict containing object metadata
+    """
+    paginator = client.get_paginator('list_objects_v2')
+    pages = paginator.paginate(Bucket=bucket, Prefix=prefix)
+    
+    for page in pages:
+        if 'Contents' in page:
+            for obj in page['Contents']:
+                yield obj
+
+
+@_retry_pattern()
+def get_s3_object(client: BaseClient, bucket: str, key: str) -> bytes:
+    """
+    Download S3 object content
+    
+    Args:
+        client: S3 client
+        bucket: S3 bucket name
+        key: S3 object key
+        
+    Returns:
+        Object content as bytes
+    """
+    response = client.get_object(Bucket=bucket, Key=key)
+    return response['Body'].read()
+
+
+@_retry_pattern()
+def delete_s3_objects_batch(client: BaseClient, bucket: str, keys: List[str]) -> int:
+    """
+    Delete multiple S3 objects in batch (up to 1000 at a time)
+    
+    Args:
+        client: S3 client
+        bucket: S3 bucket name
+        keys: List of S3 object keys to delete
+        
+    Returns:
+        Number of objects successfully deleted
+    """
+    if not keys:
+        return 0
+    
+    delete_objects = [{'Key': key} for key in keys]
+    
+    response = client.delete_objects(
+        Bucket=bucket,
+        Delete={'Objects': delete_objects}
+    )
+    
+    deleted_count = len(response.get('Deleted', []))
+    
+    # Log any errors
+    if 'Errors' in response:
+        for error in response['Errors']:
+            LOGGER.error(f"Failed to delete s3://{bucket}/{error['Key']}: {error['Message']}")
+    
+    if deleted_count > 0:
+        LOGGER.info(f"Batch deleted {deleted_count} objects from s3://{bucket}/")
+    
+    return deleted_count
+
+
+def is_jsonl_file(key: str) -> bool:
+    """
+    Check if the S3 key represents a JSONL file
+    
+    Args:
+        key: S3 object key
+        
+    Returns:
+        True if file appears to be JSONL format
+    """
+    # Check for JSONL file extension only
+    return key.lower().endswith('.jsonl')
+
+
+def cleanup_empty_jsonl_files(bucket: str, client: BaseClient, path_components: PathComponents) -> Dict[str, int]:
+    """
+    Main function to clean up JSONL files without RECORD entries
+    
+    Args:
+        bucket: S3 bucket name
+        client: S3 client to use for operations
+        path_components: Path components to construct the S3 prefix (org_id/source/repo_id)
+        
+    Returns:
+        Dict with cleanup statistics: {'files_processed': int, 'files_without_records': int, 'files_deleted': int}
+    """
+    
+    prefix = f"{path_components.org_id}/{path_components.source}/{path_components.repo_id}"
+    
+    try:
+        
+        LOGGER.info(f"Starting cleanup of JSONL files in s3://{bucket}/{prefix}")
+        
+        files_processed = 0
+        files_without_records = 0
+        files_deleted = 0
+        files_to_delete = []  # Collect files for batch deletion
+        
+        # List all objects in the bucket with the given prefix
+        for obj in list_s3_objects(client, bucket, prefix):
+            key = obj['Key']
+            size = obj['Size']
+            
+            # Skip if not a JSONL file
+            if not is_jsonl_file(key):
+                continue
+                
+            files_processed += 1
+            LOGGER.debug(f"Processing {key} ({size} bytes)")
+            
+            try:
+                # Download and immediately check file content, don't hold reference
+                if not has_record_entries(get_s3_object(client, bucket, key)):
+                    files_without_records += 1
+                    LOGGER.info(f"File s3://{bucket}/{key} has no RECORD entries")
+                    
+                    files_to_delete.append(key)
+                    
+                    # Batch delete when we hit 1000 files (S3 limit)
+                    if len(files_to_delete) >= 1000:
+                        deleted_count = delete_s3_objects_batch(client, bucket, files_to_delete)
+                        files_deleted += deleted_count
+                        files_to_delete = []  # Reset for next batch
+                        
+            except Exception as e:
+                LOGGER.error(f"Error processing s3://{bucket}/{key}: {str(e)}")
+                continue
+        
+        # Delete any remaining files in final batch
+        if files_to_delete:
+            deleted_count = delete_s3_objects_batch(client, bucket, files_to_delete)
+            files_deleted += deleted_count
+        
+        LOGGER.info(f"Cleanup completed:")
+        LOGGER.info(f"  Files processed: {files_processed}")
+        LOGGER.info(f"  Files without RECORD entries: {files_without_records}")
+        LOGGER.info(f"  Files deleted: {files_deleted}")
+        
+        return {
+            'files_processed': files_processed,
+            'files_without_records': files_without_records,
+            'files_deleted': files_deleted
+        }
+            
+    except Exception as e:
+        LOGGER.error(f"Cleanup failed: {str(e)}")
+        raise

--- a/tests/test_s3_cleanup.py
+++ b/tests/test_s3_cleanup.py
@@ -1,0 +1,204 @@
+import json
+import sys
+import os
+import unittest
+from unittest.mock import Mock, patch
+from pathlib import Path
+
+# Add src to path for imports
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+from target_s3_json.s3_cleanup import (
+    has_record_entries,
+    is_jsonl_file,
+    cleanup_empty_jsonl_files,
+    delete_s3_objects_batch
+)
+from target_s3_json.snowflake import PathComponents
+
+
+class TestRecordDetection(unittest.TestCase):
+    """Test the RECORD entry detection functionality"""
+    
+    def test_has_record_entries_with_record_on_second_line(self):
+        """Test detecting files with RECORD entries on second line"""
+        content = b'''{"type": "STATE", "value": {"currently_syncing": null}}
+{"type": "RECORD", "stream": "test", "record": {"id": 1}}
+{"type": "STATE", "value": {"currently_syncing": null}}'''
+        
+        assert has_record_entries(content) is True
+    
+    def test_has_record_entries_without_records(self):
+        """Test detecting files without RECORD entries"""
+        content = b'''{"type": "STATE", "value": {"currently_syncing": null}}
+{"type": "SCHEMA", "stream": "test", "schema": {}}
+{"type": "STATE", "value": {"currently_syncing": null}}'''
+        
+        assert has_record_entries(content) is False
+    
+    def test_has_record_entries_empty_file(self):
+        """Test empty files"""
+        content = b''
+        assert has_record_entries(content) is False
+    
+    def test_has_record_entries_single_line(self):
+        """Test files with only one line"""
+        content = b'{"type": "STATE", "value": {"currently_syncing": null}}'
+        assert has_record_entries(content) is False
+    
+    def test_has_record_entries_empty_second_line(self):
+        """Test files with empty second line"""
+        content = b'''{"type": "STATE", "value": {"currently_syncing": null}}
+
+{"type": "SCHEMA", "stream": "test", "schema": {}}'''
+        assert has_record_entries(content) is False
+    
+    def test_has_record_entries_invalid_json_second_line(self):
+        """Test files with invalid JSON on second line"""
+        content = b'''{"type": "STATE", "value": {"currently_syncing": null}}
+invalid json line
+{"type": "SCHEMA", "stream": "test", "schema": {}}'''
+        
+        assert has_record_entries(content) is False
+
+
+class TestFileTypeDetection(unittest.TestCase):
+    """Test JSONL file type detection"""
+    
+    def test_is_jsonl_file_jsonl_extension(self):
+        """Test .jsonl files are detected"""  
+        assert is_jsonl_file('test.jsonl') is True
+        assert is_jsonl_file('path/to/test.jsonl') is True
+    
+    def test_is_jsonl_file_case_insensitive(self):
+        """Test case insensitive detection"""
+        assert is_jsonl_file('test.JSONL') is True
+        assert is_jsonl_file('path/to/TEST.Jsonl') is True
+    
+    def test_is_jsonl_file_non_jsonl(self):
+        """Test non-JSONL files are not detected"""
+        assert is_jsonl_file('test.json') is False  # Only .jsonl now
+        assert is_jsonl_file('test.txt') is False
+        assert is_jsonl_file('test.csv') is False
+        assert is_jsonl_file('test.xml') is False
+        assert is_jsonl_file('test.json.gz') is False  # No compressed files
+        assert is_jsonl_file('test.jsonl.gz') is False
+
+
+class TestBatchDelete(unittest.TestCase):
+    """Test batch delete functionality"""
+    
+    def test_delete_s3_objects_batch_success(self):
+        """Test successful batch delete"""
+        mock_client = Mock()
+        mock_client.delete_objects.return_value = {
+            'Deleted': [
+                {'Key': 'file1.jsonl'},
+                {'Key': 'file2.jsonl'}
+            ]
+        }
+        
+        result = delete_s3_objects_batch(mock_client, 'test-bucket', ['file1.jsonl', 'file2.jsonl'])
+        
+        assert result == 2
+        mock_client.delete_objects.assert_called_once_with(
+            Bucket='test-bucket',
+            Delete={'Objects': [{'Key': 'file1.jsonl'}, {'Key': 'file2.jsonl'}]}
+        )
+    
+    def test_delete_s3_objects_batch_empty_list(self):
+        """Test batch delete with empty list"""
+        mock_client = Mock()
+        
+        result = delete_s3_objects_batch(mock_client, 'test-bucket', [])
+        
+        assert result == 0
+        mock_client.delete_objects.assert_not_called()
+    
+    def test_delete_s3_objects_batch_with_errors(self):
+        """Test batch delete with some errors"""
+        mock_client = Mock()
+        mock_client.delete_objects.return_value = {
+            'Deleted': [{'Key': 'file1.jsonl'}],
+            'Errors': [
+                {'Key': 'file2.jsonl', 'Message': 'Access denied'}
+            ]
+        }
+        
+        result = delete_s3_objects_batch(mock_client, 'test-bucket', ['file1.jsonl', 'file2.jsonl'])
+        
+        assert result == 1  # Only one successfully deleted
+
+
+class TestCleanupIntegration(unittest.TestCase):
+    """Integration tests for the cleanup functionality"""
+    
+    def test_cleanup_with_path_components(self):
+        """Test cleanup using PathComponents"""
+        # Setup bucket and client
+        bucket = 'test-bucket'
+        path_components = PathComponents(
+            org_id='e459f0ee-9ed2-4232-bada-dc4c05bdfd10',
+            source='github', 
+            repo_id='bb33070e-98db-4780-9ce1-36427cc73662'
+        )
+        
+        mock_client = Mock()
+        
+        # Mock S3 objects - only .jsonl files now
+        mock_client.get_paginator.return_value.paginate.return_value = [
+            {
+                'Contents': [
+                    {'Key': 'e459f0ee-9ed2-4232-bada-dc4c05bdfd10/github/bb33070e-98db-4780-9ce1-36427cc73662/file1.jsonl', 'Size': 100},
+                    {'Key': 'e459f0ee-9ed2-4232-bada-dc4c05bdfd10/github/bb33070e-98db-4780-9ce1-36427cc73662/file2.jsonl', 'Size': 200}
+                ]
+            }
+        ]
+        
+        # Mock file contents - one with RECORD on second line, one without
+        def mock_get_object(Bucket, Key):
+            mock_body = Mock()
+            if 'file1.jsonl' in Key:
+                # File with RECORD on second line
+                mock_body.read.return_value = \
+                    b'{"type": "STATE", "value": {}}\n{"type": "RECORD", "record": {"id": 1}}'
+            else:
+                # File without RECORD entries
+                mock_body.read.return_value = \
+                    b'{"type": "STATE", "value": {}}\n{"type": "SCHEMA", "stream": "test"}'
+            return {'Body': mock_body}
+        
+        mock_client.get_object.side_effect = mock_get_object
+        mock_client.delete_objects.return_value = {'Deleted': [{'Key': 'file2.jsonl'}]}
+        
+        # Run cleanup
+        result = cleanup_empty_jsonl_files(bucket, mock_client, path_components)
+        
+        # Verify results
+        assert result['files_processed'] == 2
+        assert result['files_without_records'] == 1
+        assert result['files_deleted'] == 1
+        
+        # Verify batch delete was called
+        mock_client.delete_objects.assert_called_once()
+    
+    def test_cleanup_with_empty_bucket(self):
+        """Test cleanup with empty bucket name"""
+        bucket = ''  # Empty bucket name
+        path_components = PathComponents(
+            org_id='test-org',
+            source='github', 
+            repo_id='test-repo'
+        )
+        mock_client = Mock()
+        mock_client.get_paginator.return_value.paginate.return_value = []
+        
+        # Run cleanup
+        result = cleanup_empty_jsonl_files(bucket, mock_client, path_components)
+        
+        # Should return empty results since no objects found
+        assert result == {'files_processed': 0, 'files_without_records': 0, 'files_deleted': 0}
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This adds a cleanup process to the target-json-s3 which does the following:
1. Gets a list of files in the current prefix
2. Checks that they are jsonl files
3. If the file doesn't contain a RECORD in the second line adds to to a batch for deletion
4. Deletes files in batches of 1k

Why we should do this in target-json-s3:
1. We need to refresh the stage after deleting files
2. The operates in a "per-org-per-repo" context naturally which allows an easier time than trying to do this across all orgs and repos at once.

Testing that's been completed:
1. unit tests of new functionality
2. Run in dev environment to validate that it cleans up files as expected
Before:
<img width="1853" alt="image" src="https://github.com/user-attachments/assets/c4fb68e0-c849-4201-a728-20ca56cd83a1" />

After:
<img width="1848" alt="image" src="https://github.com/user-attachments/assets/ab26cc5e-9991-4cd6-997b-cae3ef2c3991" />
