### PR TITLE
reduce batch size and add single delete

### DIFF
--- a/src/target_s3_json/s3_cleanup.py
+++ b/src/target_s3_json/s3_cleanup.py
@@ -19,11 +19,13 @@ def _log_backoff_attempt(details: Dict) -> None:
 
 
 def _retry_pattern() -> Callable:
-    def giveup_on_nosuchkey(e):
-        """Don't retry on NoSuchKey errors - file is gone, no point retrying"""
+    def giveup_on_unretryable_errors(e):
+        """Don't retry on errors that won't be fixed by retrying"""
         if isinstance(e, ClientError):
             error_code = e.response.get('Error', {}).get('Code', '')
-            return error_code == 'NoSuchKey'
+            # NoSuchKey: file is gone, no point retrying
+            # MalformedXML: object key has fundamental issues, retrying won't help
+            return error_code in ['NoSuchKey', 'MalformedXML']
         return False
     
     return backoff.on_exception(
@@ -31,7 +33,7 @@ def _retry_pattern() -> Callable:
         ClientError,
         max_tries=5,
         on_backoff=_log_backoff_attempt,
-        giveup=giveup_on_nosuchkey,
+        giveup=giveup_on_unretryable_errors,
         factor=10)
 
 
@@ -114,7 +116,7 @@ def get_s3_object(client: BaseClient, bucket: str, key: str) -> bytes:
 @_retry_pattern()
 def delete_s3_objects_batch(client: BaseClient, bucket: str, keys: List[str]) -> int:
     """
-    Delete multiple S3 objects in batch (up to 1000 at a time)
+    Delete multiple S3 objects in batch (typically called with 100 objects at a time to avoid XML size limits)
     
     Args:
         client: S3 client
@@ -127,22 +129,80 @@ def delete_s3_objects_batch(client: BaseClient, bucket: str, keys: List[str]) ->
     if not keys:
         return 0
     
-    delete_objects = [{'Key': key} for key in keys]
+    # Ensure keys are properly formatted for XML request
+    delete_objects = []
+    for key in keys:
+        # Clean up any potential issues with the key formatting
+        clean_key = key.strip()
+        if clean_key:  # Only add non-empty keys
+            delete_objects.append({'Key': clean_key})
     
-    response = client.delete_objects(
-        Bucket=bucket,
-        Delete={'Objects': delete_objects}
-    )
+    if not delete_objects:
+        return 0
     
-    deleted_count = len(response.get('Deleted', []))
+    try:
+        response = client.delete_objects(
+            Bucket=bucket,
+            Delete={
+                'Objects': delete_objects,
+                'Quiet': False  # We want to see both successes and failures
+            }
+        )
+        
+        deleted_count = len(response.get('Deleted', []))
+        
+        # Log any errors
+        if 'Errors' in response:
+            for error in response['Errors']:
+                LOGGER.error(f"Failed to delete s3://{bucket}/{error['Key']}: {error['Message']}")
+        
+        if deleted_count > 0:
+            LOGGER.info(f"Batch deleted {deleted_count} objects from s3://{bucket}/")
+        
+        return deleted_count
+        
+    except ClientError as e:
+        # If batch delete fails, fall back to individual deletes to isolate the problematic key
+        error_code = e.response.get('Error', {}).get('Code', '')
+        if error_code == 'MalformedXML':
+            LOGGER.warning(f"Batch delete failed with MalformedXML, falling back to individual deletes for {len(keys)} objects")
+            return delete_s3_objects_individually(client, bucket, keys)
+        else:
+            raise
+
+
+@_retry_pattern()
+def delete_s3_objects_individually(client: BaseClient, bucket: str, keys: List[str]) -> int:
+    """
+    Delete S3 objects one by one as fallback when batch delete fails
     
-    # Log any errors
-    if 'Errors' in response:
-        for error in response['Errors']:
-            LOGGER.error(f"Failed to delete s3://{bucket}/{error['Key']}: {error['Message']}")
+    Args:
+        client: S3 client
+        bucket: S3 bucket name
+        keys: List of S3 object keys to delete
+        
+    Returns:
+        Number of objects successfully deleted
+    """
+    deleted_count = 0
+    
+    for key in keys:
+        try:
+            client.delete_object(Bucket=bucket, Key=key)
+            deleted_count += 1
+            LOGGER.debug(f"Deleted individual object: s3://{bucket}/{key}")
+        except ClientError as e:
+            error_code = e.response.get('Error', {}).get('Code', '')
+            if error_code == 'NoSuchKey':
+                LOGGER.debug(f"Object s3://{bucket}/{key} already deleted")
+                deleted_count += 1  # Count as successful since goal is achieved
+            else:
+                LOGGER.error(f"Failed to delete s3://{bucket}/{key}: {str(e)}")
+        except Exception as e:
+            LOGGER.error(f"Unexpected error deleting s3://{bucket}/{key}: {str(e)}")
     
     if deleted_count > 0:
-        LOGGER.info(f"Batch deleted {deleted_count} objects from s3://{bucket}/")
+        LOGGER.info(f"Individually deleted {deleted_count} objects from s3://{bucket}/")
     
     return deleted_count
 
@@ -206,8 +266,8 @@ def cleanup_empty_jsonl_files(bucket: str, client: BaseClient, path_components: 
                     
                     files_to_delete.append(key)
                     
-                    # Batch delete when we hit 1000 files (S3 limit)
-                    if len(files_to_delete) >= 1000:
+                    # Batch delete when we hit 100 files (conservative limits to isolate malformed XML errors)
+                    if len(files_to_delete) >= 100:
                         deleted_count = delete_s3_objects_batch(client, bucket, files_to_delete)
                         files_deleted += deleted_count
                         files_to_delete = []  # Reset for next batch

--- a/src/target_s3_json/s3_cleanup.py
+++ b/src/target_s3_json/s3_cleanup.py
@@ -116,7 +116,7 @@ def get_s3_object(client: BaseClient, bucket: str, key: str) -> bytes:
 @_retry_pattern()
 def delete_s3_objects_batch(client: BaseClient, bucket: str, keys: List[str]) -> int:
     """
-    Delete multiple S3 objects in batch (typically called with 100 objects at a time to avoid XML size limits)
+    Delete multiple S3 objects in batch (called with 100 objects at a time to isolate potentialerrors)
     
     Args:
         client: S3 client

--- a/src/target_s3_json/s3_cleanup.py
+++ b/src/target_s3_json/s3_cleanup.py
@@ -128,13 +128,12 @@ def delete_s3_objects_batch(client: BaseClient, bucket: str, keys: List[str]) ->
     """
     if not keys:
         return 0
-
     
     try:
         response = client.delete_objects(
             Bucket=bucket,
             Delete={
-                'Objects': keys,
+                'Objects': [{'Key': key} for key in keys],
                 'Quiet': False  # We want to see both successes and failures
             }
         )

--- a/src/target_s3_json/s3_cleanup.py
+++ b/src/target_s3_json/s3_cleanup.py
@@ -136,6 +136,7 @@ def delete_s3_objects_batch(client: BaseClient, bucket: str, keys: List[str]) ->
         clean_key = key.strip()
         if clean_key:  # Only add non-empty keys
             delete_objects.append({'Key': clean_key})
+            LOGGER.info(f"Adding key to delete: {clean_key}")
     
     if not delete_objects:
         return 0
@@ -188,6 +189,7 @@ def delete_s3_objects_individually(client: BaseClient, bucket: str, keys: List[s
     
     for key in keys:
         try:
+            LOGGER.info(f"Deleting individual object: s3://{bucket}/{key}")
             client.delete_object(Bucket=bucket, Key=key)
             deleted_count += 1
             LOGGER.debug(f"Deleted individual object: s3://{bucket}/{key}")

--- a/src/target_s3_json/s3_cleanup.py
+++ b/src/target_s3_json/s3_cleanup.py
@@ -128,24 +128,13 @@ def delete_s3_objects_batch(client: BaseClient, bucket: str, keys: List[str]) ->
     """
     if not keys:
         return 0
-    
-    # Ensure keys are properly formatted for XML request
-    delete_objects = []
-    for key in keys:
-        # Clean up any potential issues with the key formatting
-        clean_key = key.strip()
-        if clean_key:  # Only add non-empty keys
-            delete_objects.append({'Key': clean_key})
-            LOGGER.info(f"Adding key to delete: {clean_key}")
-    
-    if not delete_objects:
-        return 0
+
     
     try:
         response = client.delete_objects(
             Bucket=bucket,
             Delete={
-                'Objects': delete_objects,
+                'Objects': keys,
                 'Quiet': False  # We want to see both successes and failures
             }
         )

--- a/tests/test_s3_cleanup.py
+++ b/tests/test_s3_cleanup.py
@@ -12,7 +12,8 @@ from target_s3_json.s3_cleanup import (
     has_record_entries,
     is_jsonl_file,
     cleanup_empty_jsonl_files,
-    delete_s3_objects_batch
+    delete_s3_objects_batch,
+    delete_s3_objects_individually
 )
 from target_s3_json.snowflake import PathComponents
 
@@ -103,7 +104,10 @@ class TestBatchDelete(unittest.TestCase):
         assert result == 2
         mock_client.delete_objects.assert_called_once_with(
             Bucket='test-bucket',
-            Delete={'Objects': [{'Key': 'file1.jsonl'}, {'Key': 'file2.jsonl'}]}
+            Delete={
+                'Objects': [{'Key': 'file1.jsonl'}, {'Key': 'file2.jsonl'}],
+                'Quiet': False
+            }
         )
     
     def test_delete_s3_objects_batch_empty_list(self):
@@ -128,6 +132,141 @@ class TestBatchDelete(unittest.TestCase):
         result = delete_s3_objects_batch(mock_client, 'test-bucket', ['file1.jsonl', 'file2.jsonl'])
         
         assert result == 1  # Only one successfully deleted
+
+    @patch('target_s3_json.s3_cleanup.delete_s3_objects_individually')
+    def test_delete_s3_objects_batch_malformed_xml_fallback(self, mock_individual_delete):
+        """Test batch delete falls back to individual deletes on MalformedXML error"""
+        from botocore.exceptions import ClientError
+        
+        mock_client = Mock()
+        mock_client.delete_objects.side_effect = ClientError(
+            error_response={'Error': {'Code': 'MalformedXML', 'Message': 'XML malformed'}},
+            operation_name='DeleteObjects'
+        )
+        
+        mock_individual_delete.return_value = 2
+        
+        result = delete_s3_objects_batch(mock_client, 'test-bucket', ['file1.jsonl', 'file2.jsonl'])
+        
+        assert result == 2
+        mock_individual_delete.assert_called_once_with(mock_client, 'test-bucket', ['file1.jsonl', 'file2.jsonl'])
+    
+    def test_batch_size_conservative_for_xml_limits(self):
+        """Test that we use conservative batch sizes to avoid XML payload limits"""
+        # This test documents that we use 100 objects per batch instead of 1000
+        # to avoid XML payload size issues with long S3 object keys
+        
+        bucket = 'test-bucket'
+        path_components = PathComponents(
+            org_id='long-org-id-that-takes-space',
+            source='github', 
+            repo_id='long-repo-id-that-also-takes-space'
+        )
+        
+        mock_client = Mock()
+        
+        # Create 150 mock objects with long keys (similar to real scenario)
+        long_keys = []
+        for i in range(150):
+            long_key = f"{path_components.org_id}/{path_components.source}/{path_components.repo_id}/2025/01/01/123456/very_long_filename_that_simulates_real_world_scenario_part_{i:05d}.jsonl"
+            long_keys.append({'Key': long_key, 'Size': 100})
+        
+        # Mock paginated response
+        mock_client.get_paginator.return_value.paginate.return_value = [
+            {'Contents': long_keys}
+        ]
+        
+        # Mock all files as having no RECORD entries
+        def mock_get_object(Bucket, Key):
+            mock_body = Mock()
+            mock_body.read.return_value = b'{"type": "STATE", "value": {}}\n{"type": "SCHEMA", "stream": "test"}'
+            return {'Body': mock_body}
+        
+        mock_client.get_object.side_effect = mock_get_object
+        mock_client.delete_objects.return_value = {'Deleted': [{'Key': 'dummy'}] * 100}  # Mock successful batch delete
+        
+        # Run cleanup
+        result = cleanup_empty_jsonl_files(bucket, mock_client, path_components)
+        
+        # Should process all 150 files
+        assert result['files_processed'] == 150
+        assert result['files_without_records'] == 150
+        
+        # Should call batch delete twice: once at 100 files, once for remaining 50
+        assert mock_client.delete_objects.call_count == 2
+
+
+class TestIndividualDelete(unittest.TestCase):
+    """Test individual delete functionality"""
+    
+    def test_delete_s3_objects_individually_success(self):
+        """Test successful individual deletes"""
+        mock_client = Mock()
+        mock_client.delete_object.return_value = {}
+        
+        result = delete_s3_objects_individually(mock_client, 'test-bucket', ['file1.jsonl', 'file2.jsonl'])
+        
+        assert result == 2
+        assert mock_client.delete_object.call_count == 2
+        mock_client.delete_object.assert_any_call(Bucket='test-bucket', Key='file1.jsonl')
+        mock_client.delete_object.assert_any_call(Bucket='test-bucket', Key='file2.jsonl')
+    
+    def test_delete_s3_objects_individually_no_such_key(self):
+        """Test individual delete when files don't exist"""
+        from botocore.exceptions import ClientError
+        
+        mock_client = Mock()
+        mock_client.delete_object.side_effect = ClientError(
+            error_response={'Error': {'Code': 'NoSuchKey', 'Message': 'Key not found'}},
+            operation_name='DeleteObject'
+        )
+        
+        result = delete_s3_objects_individually(mock_client, 'test-bucket', ['file1.jsonl'])
+        
+        assert result == 1  # Still count as successful since goal is achieved
+    
+    def test_delete_s3_objects_individually_malformed_xml(self):
+        """Test individual delete when key causes MalformedXML - should not retry"""
+        from botocore.exceptions import ClientError
+        
+        mock_client = Mock()
+        mock_client.delete_object.side_effect = ClientError(
+            error_response={'Error': {'Code': 'MalformedXML', 'Message': 'XML malformed'}},
+            operation_name='DeleteObject'
+        )
+        
+        result = delete_s3_objects_individually(mock_client, 'test-bucket', ['problematic-key.jsonl'])
+        
+        # Should not count as successful since the key has fundamental issues
+        assert result == 0
+        # Should only call delete_object once (no retries for MalformedXML)
+        assert mock_client.delete_object.call_count == 1
+    
+    def test_delete_s3_objects_individually_mixed_results(self):
+        """Test individual delete with mixed success/failure"""
+        from botocore.exceptions import ClientError
+        
+        mock_client = Mock()
+        
+        def side_effect(Bucket, Key):
+            if Key == 'file1.jsonl':
+                return {}  # Success
+            elif Key == 'file2.jsonl':
+                raise ClientError(
+                    error_response={'Error': {'Code': 'NoSuchKey', 'Message': 'Key not found'}},
+                    operation_name='DeleteObject'
+                )
+            else:
+                raise ClientError(
+                    error_response={'Error': {'Code': 'AccessDenied', 'Message': 'Access denied'}},
+                    operation_name='DeleteObject'  
+                )
+        
+        mock_client.delete_object.side_effect = side_effect
+        
+        result = delete_s3_objects_individually(mock_client, 'test-bucket', ['file1.jsonl', 'file2.jsonl', 'file3.jsonl'])
+        
+        assert result == 2  # file1 success + file2 NoSuchKey (counted as success)
 
 
 class TestCleanupIntegration(unittest.TestCase):


### PR DESCRIPTION
This is in response to the MalformedXML errors that we are getting for some orgs. Those errors were being retried with exponential backoff and jobs were running for a very long time.

It adds the following logic:

If a deleteObjects call fails with the MalformedXML error, it will attempt to call deleteObject for each object in the batch. 

If individual calls to deleteObject fail with MalformedXML, then it logs and doesn't attempt to retry.

The batch size is reduced to 100.

