### PR TITLE
Do not write state to files in s3

### DIFF
--- a/src/target_s3_json/s3.py
+++ b/src/target_s3_json/s3.py
@@ -303,7 +303,11 @@ def main(lines: TextIO = sys.stdin) -> None:
             Loader(config | {'client': client, 'executor': executor, 'add_metadata_columns': True }, writeline=save_s3).run(curLines)
         if not curLines.stoppedState():
             break
-    
+
+    # If snowflake_stage is set to False, skip stage creation/refresh
+    if config.get('snowflake_stage', True) == False:
+        return
+
     # After processing is complete, create and refresh the Snowflake stage
     stage = None
     try:

--- a/src/target_s3_json/stream.py
+++ b/src/target_s3_json/stream.py
@@ -269,7 +269,8 @@ class Loader():
         for stream in self.stream_data:
             # Write last state line at the end of every file so that we know it is complete
             if lastStateLine:
-                await self.writeline(stream, self.stream_data, self.config, lastStateLine)
+                empty_state = { **lastStateLine, 'value': {} }
+                await self.writeline(stream, self.stream_data, self.config, empty_state)
             await self.writeline(stream, self.stream_data, self.config)
 
         return self.state, self.stream_data


### PR DESCRIPTION

## How was this tested
- [x] Ran locally, verified STATE records have an empty value
- [x] Ran locally, verified that state was still being written to stdout and passed through uploadState
- [x] Verified snowlfake staging does not occur when snowflake_stage is set to false